### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.1.1](https://github.com/stvnksslr/khelp/compare/v0.1.0...v0.1.1) - 2025-03-25
+
+### Other
+- chore(pre-commit + readme fixes): (by @stvnksslr)
+- chore(readme): (by @stvnksslr)
+- chore(repo name): (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "khelp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khelp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "A tool for managing kubernetes contexts"
 repository = "https://github.com/stvnksslr/khelp"


### PR DESCRIPTION



## 🤖 New release

* `khelp`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/stvnksslr/khelp/compare/v0.1.0...v0.1.1) - 2025-03-25

### Other
- chore(pre-commit + readme fixes): (by @stvnksslr)
- chore(readme): (by @stvnksslr)
- chore(repo name): (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).