### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3](https://github.com/stvnksslr/khelp/compare/v0.1.2...v0.1.3) - 2025-03-28
+
+### Added
+- *(self_update + shell completions)* added self updater feature + shell completions for bash, zsh and fish (by @stvnksslr)
+- *(self_update + shell completions)* added self updater feature + shell completions for bash, zsh and fish (by @stvnksslr)
+
+### Fixed
+- *(backups)* backups were happening on switch events, which i had when debugging but are not needed at all now (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [0.1.2](https://github.com/stvnksslr/khelp/compare/v0.1.1...v0.1.2) - 2025-03-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "khelp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khelp"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A tool for managing kubernetes contexts"
 repository = "https://github.com/stvnksslr/khelp"


### PR DESCRIPTION



## 🤖 New release

* `khelp`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/stvnksslr/khelp/compare/v0.1.2...v0.1.3) - 2025-03-28

### Added
- *(self_update + shell completions)* added self updater feature + shell completions for bash, zsh and fish (by @stvnksslr)
- *(self_update + shell completions)* added self updater feature + shell completions for bash, zsh and fish (by @stvnksslr)

### Fixed
- *(backups)* backups were happening on switch events, which i had when debugging but are not needed at all now (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).