### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.4](https://github.com/stvnksslr/khelp/compare/v0.1.3...v0.1.4) - 2025-09-02
+
+### Added
+- *(code cleanup + tests)* improving test coverage and breaking up large complicated functions
+
+### Fixed
+- *(backups)* made backups more intentional
+
+### Other
+- *(config)* tests would edit the users config
 ## [0.1.3](https://github.com/stvnksslr/khelp/compare/v0.1.2...v0.1.3) - 2025-03-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "khelp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khelp"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "A tool for managing kubernetes contexts"
 repository = "https://github.com/stvnksslr/khelp"


### PR DESCRIPTION



## 🤖 New release

* `khelp`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/stvnksslr/khelp/compare/v0.1.3...v0.1.4) - 2025-09-02

### Added
- *(code cleanup + tests)* improving test coverage and breaking up large complicated functions

### Fixed
- *(backups)* made backups more intentional

### Other
- *(config)* tests would edit the users config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).