### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.7](https://github.com/stvnksslr/khelp/compare/v0.1.6...v0.1.7) - 2025-09-07
+
+### Added
+- *(self_update + shell completions)* added self updater feature + shell completions for bash, zsh and fish (by @stvnksslr)
+- *(self_update + shell completions)* added self updater feature + shell completions for bash, zsh and fish (by @stvnksslr)
+
+### Fixed
+- *(backups)* made backups more intentional (by @stvnksslr)
+- *(backups)* backups were happening on switch events, which i had when debugging but are not needed at all now (by @stvnksslr)
+
+### Other
+- bugfixe(fixing release flow): (by @stvnksslr)
+- release v0.1.3 (by @stvnksslr)
+- release v0.1.2 (by @stvnksslr)
+- chore(pre-commit + readme fixes): (by @stvnksslr)
+- release v0.1.1 (by @stvnksslr)
+- chore(pre-commit + readme fixes): (by @stvnksslr)
+- chore(readme): (by @stvnksslr)
+- chore(repo name): (by @stvnksslr)
+- chore(formatting): (by @stvnksslr)
+- chore(formatting): (by @stvnksslr)
+- initial commit (by @stvnksslr)
+- initial commit (by @stvnksslr)
+- initial commit (by @stvnksslr)
+- initial commit (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [0.1.3](https://github.com/stvnksslr/khelp/compare/v0.1.2...v0.1.3) - 2025-03-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "khelp"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khelp"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "A tool for managing kubernetes contexts"
 repository = "https://github.com/stvnksslr/khelp"


### PR DESCRIPTION



## 🤖 New release

* `khelp`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/stvnksslr/khelp/compare/v0.1.6...v0.1.7) - 2025-09-07

### Added
- *(self_update + shell completions)* added self updater feature + shell completions for bash, zsh and fish (by @stvnksslr)
- *(self_update + shell completions)* added self updater feature + shell completions for bash, zsh and fish (by @stvnksslr)

### Fixed
- *(backups)* made backups more intentional (by @stvnksslr)
- *(backups)* backups were happening on switch events, which i had when debugging but are not needed at all now (by @stvnksslr)

### Other
- bugfixe(fixing release flow): (by @stvnksslr)
- release v0.1.3 (by @stvnksslr)
- release v0.1.2 (by @stvnksslr)
- chore(pre-commit + readme fixes): (by @stvnksslr)
- release v0.1.1 (by @stvnksslr)
- chore(pre-commit + readme fixes): (by @stvnksslr)
- chore(readme): (by @stvnksslr)
- chore(repo name): (by @stvnksslr)
- chore(formatting): (by @stvnksslr)
- chore(formatting): (by @stvnksslr)
- initial commit (by @stvnksslr)
- initial commit (by @stvnksslr)
- initial commit (by @stvnksslr)
- initial commit (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).