### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.8](https://github.com/stvnksslr/khelp/compare/v0.1.7...v0.1.8) - 2025-10-08
+
+### Added
+- *(add + remove + tests)* add command that can import contexts from a file, remove to delete a context and some basic tests and changes to make sure that these are in isolation of the users kube config file (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [0.1.7](https://github.com/stvnksslr/khelp/compare/v0.1.6...v0.1.7) - 2025-09-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "khelp"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khelp"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "A tool for managing kubernetes contexts"
 repository = "https://github.com/stvnksslr/khelp"


### PR DESCRIPTION



## 🤖 New release

* `khelp`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8](https://github.com/stvnksslr/khelp/compare/v0.1.7...v0.1.8) - 2025-10-08

### Added
- *(add + remove + tests)* add command that can import contexts from a file, remove to delete a context and some basic tests and changes to make sure that these are in isolation of the users kube config file (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).