### PR TITLE
chore: release v0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.16](https://github.com/stvnksslr/khelp/compare/v0.1.15...v0.1.16) - 2026-03-13
+
+### Added
+- *(short codes for all actions)* ) (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [0.1.15](https://github.com/stvnksslr/khelp/compare/v0.1.14...v0.1.15) - 2025-12-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "khelp"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khelp"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 description = "A tool for managing kubernetes contexts"
 repository = "https://github.com/stvnksslr/khelp"


### PR DESCRIPTION



## 🤖 New release

* `khelp`: 0.1.15 -> 0.1.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.16](https://github.com/stvnksslr/khelp/compare/v0.1.15...v0.1.16) - 2026-03-13

### Added
- *(short codes for all actions)* ) (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).